### PR TITLE
docs: add READMEs for exp/ and proto/, update README to link to directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,16 @@
 
 ![u-iot](logo/logo2.png "u-iot logo")
 
+###### The Go gopher was designed by [Renee French](http://reneefrench.blogspot.com/). The design is licensed under the Creative Commons 3.0 Attributions license. Read [this article](https://blog.golang.org/gopher) for more details.
+
 A framework and protocol for building your own smart home devices and applications. Intended to provide complete freedom in device functionality, u-iot will support applications on host operating systems, as well as embedded devices with abilities and parameters on Raspberry Pi.
 
 u-iot will be written in Go.
 
+## Progress
+
+u-iot is _very_ work-in-progress. Experimental programs demonstrating future behavior can be found in [`exp/`](exp/) with docs describing each program's purpose. WIP protocol buffers are in [`proto/`](proto/), as well as documentation on the communication process for anyone interested in implementing other languages.
+
 ## More to come in the future!
 
  See the [Design Doc](DESIGN.md) for what this project will become.
-
-###### The Go gopher was designed by [Renee French](http://reneefrench.blogspot.com/). The design is licensed under the Creative Commons 3.0 Attributions license. Read [this article](https://blog.golang.org/gopher) for more details.

--- a/exp/README.md
+++ b/exp/README.md
@@ -1,0 +1,6 @@
+# Experimental Programs
+
+Here you can find various programs demonstrating technologies and behaviors used in the u-iot libraries.
+
+* `multicast` - Go and Python chat programs that use UDP multicasting to send and receive messages. Used to familiarize myself with networking and multicast syntax in the two first u-iot libraries.
+* `grpc` - Go program that uses our [`protocol buffers`](proto/) and gRPC in tandem with multicasting to demonstrate a stripped down bootstrapping process that will be used in u-iot. This program was a proof-of-concept, many of the demonstrated interfaces are likely to change.

--- a/proto/README.md
+++ b/proto/README.md
@@ -1,0 +1,46 @@
+# Protocols
+
+u-iot communicates using a number of technologies. This README documents each component and the steps required for bootstrapping and sending commands, both for documentation and implementation in other languages in the future.
+
+### Protocol Buffers and gRPC
+
+u-iot's main functionality is in `uiot.proto` in this directory. Described there are the RPC interfaces and messages that are sent between devices.
+
+#### Bootstrapping RPCs
+
+* `DevInfo` is sent and received on startup, containing a device's IP, port, human-readable meta information, and a set of `FuncDef`s describing the functions it performs.
+
+* `FuncDef` describes a function a device performs. Contains an ID, human-readable name, and a list of `ParamDef`s, each representing a minimum and maximum value the function expects.
+
+#### Triggering RPCs
+
+* TBD
+
+### Multicasting
+
+gRPC communication requires knowing a remote device's IP and port number. To get that information, we send UDP multicast packets to a group that all u-iot devices are listening on. Each packet contains the port the device is using for RPC communication, encoded in big-endian.
+
+## Bootstrapping Process
+
+When a u-iot program starts, it bootstraps itself with all other u-iot programs on the network. The steps a new program takes are as follows:
+
+```
+local device                           router                    remote device(s)
+     |                                   |                              |
+     |     send RPC port over UDP to     |  >---->---->---->---->---->  |
+  1. |  >---->---->---->---->---->---->  |    forward to all devices    |
+     |   multicast addr 239.0.0.0:1024   |  >---->---->---->---->---->  |
+     |                                   |                              |
+     |                                                                  |
+     |         send Bootstrap RPC with remote device information        |
+  2. |  <----<----<----<----<----<----<-----<----<----<----<----<----<  |
+     |                                                                  |
+     |        respond to Bootstrap with local device information        |
+  3. |  >---->---->---->---->---->---->----->---->---->---->---->---->  |
+     |                                                                  |
+```
+1. All u-iot devices have a UDP server listening on `239.0.0.0:1024`. When a new device starts up, it sends the port its gRPC server is using to this address, encoded in 2 network-order (big-endian) bytes. Since this IP is a multicast address, the router copies the sent packet for every other device on the network.
+
+2. Using the gRPC port and source IP received in step 1, all remote devices send a Bootstrap RPC with their device information to the new device. The new device saves this info to their set of known devices.
+
+3. The new device responds to the remote RPCs with its own device info, saving it to their sets. All existing devices know about the new device, and the new device knows about all existing devices.


### PR DESCRIPTION

Signed-off-by: Trevor Farrelly <farrellytrevor@gmail.com>

**PR Purpose**

This update is primarily for the new README in /proto, where I've begun to document the communication process.

**Relevant Issues**
<!--
Automatically close relevant issues
Usage: `Fixes #<issue number>`
-->
Fixes #8 

**Notes**
<!--
Remember to tag this PR with a relevant label!
-->
